### PR TITLE
Add markdown and text file support for CVs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Released]
 
+## [0.1.2] - 2025-08-05
+
+### Changed
+- Add markdown and text file support for CVs
+
+
 ## [0.1.1] - 2025-07-17
 
 ### Changed

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    cv-parser (0.1.1)
+    cv-parser (0.1.2)
       base64 (~> 0.2)
       faraday (>= 1.0)
       faraday-multipart (>= 1.0)
@@ -26,7 +26,7 @@ GEM
     date (3.4.1)
     diff-lcs (1.6.2)
     erb (5.0.2)
-    faraday (2.13.2)
+    faraday (2.13.4)
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger
@@ -36,19 +36,19 @@ GEM
       net-http (>= 0.5.0)
     fiddle (1.1.8)
     hashdiff (1.2.0)
-    json (2.13.0)
+    json (2.13.2)
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
     logger (1.7.0)
     mime-types (3.7.0)
       logger
       mime-types-data (~> 3.2025, >= 3.2025.0507)
-    mime-types-data (3.2025.0715)
+    mime-types-data (3.2025.0729)
     multipart-post (2.4.1)
     net-http (0.6.0)
       uri
     parallel (1.27.0)
-    parser (3.3.8.0)
+    parser (3.3.9.0)
       ast (~> 2.4.1)
       racc
     prism (1.4.0)
@@ -62,7 +62,7 @@ GEM
     rdoc (6.14.2)
       erb
       psych (>= 4.0.0)
-    regexp_parser (2.10.0)
+    regexp_parser (2.11.0)
     rexml (3.4.1)
     rspec (3.13.1)
       rspec-core (~> 3.13.0)
@@ -77,7 +77,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
     rspec-support (3.13.4)
-    rubocop (1.78.0)
+    rubocop (1.79.1)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.1.0)
@@ -85,7 +85,7 @@ GEM
       parser (>= 3.3.0.2)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 2.9.3, < 3.0)
-      rubocop-ast (>= 1.45.1, < 2.0)
+      rubocop-ast (>= 1.46.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 4.0)
     rubocop-ast (1.46.0)

--- a/lib/cv_parser/configuration.rb
+++ b/lib/cv_parser/configuration.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 module CvParser
+  # Configuration settings for CV parser including LLM provider, API credentials, and extraction options
   class Configuration
     attr_accessor :provider, :model, :api_key, :timeout, :max_retries, :prompt, :system_prompt,
                   :output_schema, :max_tokens, :temperature

--- a/lib/cv_parser/errors.rb
+++ b/lib/cv_parser/errors.rb
@@ -11,4 +11,7 @@ module CvParser
   class InvalidRequestError < APIError; end
   class FileNotFoundError < Error; end
   class FileNotReadableError < Error; end
+  class TextFileError < Error; end
+  class TextFileEncodingError < TextFileError; end
+  class EmptyTextFileError < TextFileError; end
 end

--- a/lib/cv_parser/extractor.rb
+++ b/lib/cv_parser/extractor.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 module CvParser
+  # Extracts structured data from CV/resume files using configured LLM providers
   class Extractor
     def initialize(config = CvParser.configuration)
       @config = config

--- a/lib/cv_parser/pdf_converter.rb
+++ b/lib/cv_parser/pdf_converter.rb
@@ -5,6 +5,7 @@ require "rexml/document"
 require "rexml/xpath"
 
 module CvParser
+  # Converts DOCX files to PDF format by extracting text content and rendering it as PDF pages
   class PdfConverter
     # Constants modules for better organization
     module PageConstants

--- a/lib/cv_parser/providers/faker.rb
+++ b/lib/cv_parser/providers/faker.rb
@@ -27,16 +27,31 @@ module CvParser
       JSON_SCHEMA_TYPE = "json_schema"
 
       def extract_data(output_schema:, file_path: nil)
-        validate_schema_format!(output_schema)
+        validate_inputs!(output_schema, file_path)
         generate_fake_data(output_schema)
       end
 
-      def upload_file(file_path)
+      def upload_file(_file_path)
         # No-op for faker provider
         { id: "fake-file-#{SecureRandom.hex(8)}" }
       end
 
       private
+
+      def validate_inputs!(output_schema, file_path)
+        validate_schema_format!(output_schema)
+
+        # Validate file if provided
+        return unless file_path
+
+        validate_file_exists!(file_path)
+        validate_file_readable!(file_path)
+
+        # For text files, validate content
+        return unless text_file?(file_path)
+
+        read_text_file_content(file_path) # Just for validation
+      end
 
       def validate_schema_format!(output_schema)
         return if valid_json_schema_format?(output_schema)
@@ -129,7 +144,7 @@ module CvParser
         end
       end
 
-      def generate_string_value(key, description = nil)
+      def generate_string_value(key, _description = nil)
         key_string = key.to_s.downcase
 
         case key_string

--- a/lib/cv_parser/version.rb
+++ b/lib/cv_parser/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module CvParser
-  VERSION = "0.1.1"
+  VERSION = "0.1.2"
 end

--- a/spec/cv_parser/cli_spec.rb
+++ b/spec/cv_parser/cli_spec.rb
@@ -102,5 +102,34 @@ RSpec.describe CvParser::CLI do
         expect(output.string).to include("name: John Doe")
       end
     end
+
+    context "with text files" do
+      let(:txt_file) { fixture_path("sample_resume.txt") }
+      let(:md_file) { fixture_path("sample_resume.md") }
+      let(:empty_file) { fixture_path("empty_resume.txt") }
+
+      it "processes txt files successfully" do
+        cli.run(["--provider", "faker", txt_file])
+        expect(output.string).to include("Parsing CV: #{txt_file}")
+        expect(output.string).to include("Using provider: faker")
+        expect(output.string).to include("John Doe")
+      end
+
+      it "processes markdown files successfully" do
+        cli.run(["--provider", "faker", md_file])
+        expect(output.string).to include("Parsing CV: #{md_file}")
+        expect(output.string).to include("Using provider: faker")
+        expect(output.string).to include("John Doe")
+      end
+
+      it "handles non-existent text files gracefully" do
+        begin
+          cli.run(["--provider", "faker", "non_existent.txt"])
+        rescue SystemExit
+          # Expected behavior
+        end
+        expect(output.string).to match(/Error:.*not found/i)
+      end
+    end
   end
 end

--- a/spec/cv_parser/providers/base_spec.rb
+++ b/spec/cv_parser/providers/base_spec.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe CvParser::Providers::Base do
+  let(:config) do
+    config = CvParser::Configuration.new
+    config.provider = :test
+    config.api_key = "fake-api-key"
+    config
+  end
+
+  let(:provider) { described_class.new(config) }
+  let(:txt_file_path) { fixture_path("sample_resume.txt") }
+  let(:md_file_path) { fixture_path("sample_resume.md") }
+  let(:pdf_file_path) { fixture_path("cv_example.docx") } # We'll pretend this is a PDF
+  let(:empty_file_path) { fixture_path("empty_resume.txt") }
+
+  describe "#text_file?" do
+    it "returns true for .txt files" do
+      expect(provider.send(:text_file?, txt_file_path)).to be true
+    end
+
+    it "returns true for .md files" do
+      expect(provider.send(:text_file?, md_file_path)).to be true
+    end
+
+    it "returns false for .pdf files" do
+      expect(provider.send(:text_file?, pdf_file_path)).to be false
+    end
+
+    it "is case insensitive" do
+      expect(provider.send(:text_file?, "test.TXT")).to be true
+      expect(provider.send(:text_file?, "test.MD")).to be true
+    end
+  end
+
+  describe "#read_text_file_content" do
+    context "with valid text file" do
+      it "reads the content successfully" do
+        content = provider.send(:read_text_file_content, txt_file_path)
+        expect(content).to include("John Doe")
+        expect(content).to include("Software Engineer")
+      end
+    end
+
+    context "with empty text file" do
+      it "raises EmptyTextFileError" do
+        expect do
+          provider.send(:read_text_file_content, empty_file_path)
+        end.to raise_error(CvParser::EmptyTextFileError, /Text file is empty/)
+      end
+    end
+
+    context "with non-existent file" do
+      it "raises appropriate error" do
+        expect do
+          provider.send(:read_text_file_content, "non_existent.txt")
+        end.to raise_error(Errno::ENOENT)
+      end
+    end
+  end
+
+  describe "#convert_to_pdf_if_needed" do
+    it "returns the original path for text files" do
+      result = provider.send(:convert_to_pdf_if_needed, txt_file_path)
+      expect(result).to eq(txt_file_path)
+    end
+
+    it "returns the original path for markdown files" do
+      result = provider.send(:convert_to_pdf_if_needed, md_file_path)
+      expect(result).to eq(md_file_path)
+    end
+  end
+
+  describe "#extract_data" do
+    it "raises NotImplementedError" do
+      expect do
+        provider.extract_data(output_schema: {}, file_path: txt_file_path)
+      end.to raise_error(NotImplementedError)
+    end
+  end
+
+  describe "#upload_file" do
+    it "raises NotImplementedError" do
+      expect do
+        provider.upload_file(txt_file_path)
+      end.to raise_error(NotImplementedError)
+    end
+  end
+end

--- a/spec/fixtures/sample_resume.txt
+++ b/spec/fixtures/sample_resume.txt
@@ -1,0 +1,47 @@
+John Doe
+Software Engineer
+
+Email: john.doe@example.com
+Phone: (555) 123-4567
+Location: San Francisco, CA
+LinkedIn: linkedin.com/in/johndoe
+
+SUMMARY
+
+Experienced software engineer with 5+ years of expertise in Ruby, Rails, and web development. Passionate about clean code, test-driven development, and building scalable applications.
+
+WORK EXPERIENCE
+
+Senior Software Engineer
+TechCorp Inc. | Jan 2020 - Present
+
+- Led development of RESTful APIs using Ruby on Rails
+- Implemented CI/CD pipeline with GitHub Actions
+- Reduced application load time by 40% through optimization
+
+Software Developer
+WebSolutions Ltd. | Mar 2018 - Dec 2019
+
+- Developed and maintained Ruby on Rails applications
+- Created responsive web interfaces using React.js
+- Collaborated with UX designers to implement new features
+
+EDUCATION
+
+Bachelor of Science in Computer Science
+University of Technology | 2014 - 2018
+
+- GPA: 3.8/4.0
+- Relevant coursework: Data Structures, Algorithms, Web Development
+
+SKILLS
+
+Languages: Ruby, JavaScript, Python, SQL
+Frameworks: Ruby on Rails, React.js, Vue.js
+Tools: Git, Docker, AWS, Redis
+Methodologies: Agile, TDD, BDD
+
+CERTIFICATIONS
+
+- AWS Certified Developer - Associate
+- Ruby Association Certified Ruby Programmer

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 require "cv_parser"
+require "rspec/support"
+require "rspec/support/differ"
 require "webmock/rspec"
 
 RSpec.configure do |config|


### PR DESCRIPTION
## Description

**Add support for TXT and Markdown file formats**

This PR extends CV Parser to support text (.txt) and Markdown (.md) files, providing faster processing by bypassing file uploads for text-based content.

### Key Changes

**New Features:**
- **Text file support**: Direct processing of `.txt` and `.md` files
- **Performance optimization**: Text files are processed directly without upload, significantly reducing processing time
- **Smart file handling**: Automatic detection of text vs binary files

**Technical Enhancements:**
- Added new error types: `TextFileError`, `TextFileEncodingError`, `EmptyTextFileError`
- Enhanced validation for text file content and encoding
- Updated all providers (OpenAI, Anthropic, Faker) to handle text files

**Documentation:**
- Updated README with file format comparison table
- New usage examples for text file processing